### PR TITLE
feat(groovy): Groovy 3 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
                     <ignoreEOLStyle>true</ignoreEOLStyle>
                     <!-- build.log files fail build on windows-->
                     <noLog>true</noLog>
+                    <skip>${skipTests}</skip>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/resources/archetype-resources/groovy-pom.xml
+++ b/src/main/resources/archetype-resources/groovy-pom.xml
@@ -21,11 +21,15 @@
         <!-- Bonita -->
         <bonita.version>${bonitaVersion}</bonita.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
-        <groovy-all.version>2.4.21</groovy-all.version>
+        <groovy.version>#if( $bonitaVersion.matches('7.(1[3-9]|[2-9][0-9]).*') || $bonitaVersion.matches('[8-99].[0-9]+.*') )
+3.0.7#else
+2.4.21#end</groovy.version>
 
         <!-- Test -->
-        <spock-core.version>1.3-groovy-2.4</spock-core.version>
-        <byte-buddy.version>1.10.13</byte-buddy.version>
+        <spock-core.version>#if( $bonitaVersion.matches('7.(1[3-9]|[2-9][0-9]).*') || $bonitaVersion.matches('[8-99].[0-9]+.*') )
+2.0-M4-groovy-3.0#else
+1.3-groovy-2.4#end</spock-core.version>
+        <byte-buddy.version>1.10.22</byte-buddy.version>
         <logback-classic.version>1.2.3</logback-classic.version>
 
         <!-- Maven plugins -->
@@ -33,8 +37,11 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
-        <groovy-eclipse-compiler.version>3.6.0-03</groovy-eclipse-compiler.version>
-        <groovy-eclipse-batch.version>2.4.21-01</groovy-eclipse-batch.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <groovy-eclipse-compiler.version>3.7.0</groovy-eclipse-compiler.version>
+        <groovy-eclipse-batch.version>#if( $bonitaVersion.matches('7.(1[3-9]|[2-9][0-9]).*') || $bonitaVersion.matches('[8-99].[0-9]+.*') )
+3.0.7-03#else
+2.4.21-01#end</groovy-eclipse-batch.version>
 
     </properties>
 
@@ -56,13 +63,28 @@
             <scope>provided</scope>
         </dependency>
 #end
-
+#if( $bonitaVersion.matches('7.(1[3-9]|[2-9][0-9]).*') || $bonitaVersion.matches('[8-99].[0-9]+.*') )
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-json</artifactId>
+            <version>${groovy.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- You may add more Groovy modules if required, see https://groovy-lang.org/documentation.html#groovymoduleguides -->
+#else
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>${groovy-all.version}</version>
+            <version>${groovy.version}</version>
             <scope>provided</scope>
         </dependency>
+#end
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -122,10 +144,22 @@
         </dependency>
 
     </dependencies>
+    
     <build>
         <defaultGoal>verify</defaultGoal>
         <sourceDirectory>src/main/groovy</sourceDirectory>
         <testSourceDirectory>src/test/groovy</testSourceDirectory>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources/archetype-resources/src/test/groovy/IndexTest.groovy
+++ b/src/main/resources/archetype-resources/src/test/groovy/IndexTest.groovy
@@ -27,7 +27,7 @@ import com.bonitasoft.web.extension.rest.RestAPIContext
 import java.time.LocalDate;
 
 /**
- * @see http://spockframework.github.io/spock/docs/1.0/index.html
+ * @see http://spockframework.github.io/spock/docs/
  */
 class IndexTest extends Specification {
 

--- a/src/test/resources/projects/testDatasourceProject/reference/pom.xml
+++ b/src/test/resources/projects/testDatasourceProject/reference/pom.xml
@@ -19,11 +19,11 @@
         <!-- Bonita -->
         <bonita.version>7.10.0</bonita.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
-        <groovy-all.version>2.4.21</groovy-all.version>
+        <groovy.version>2.4.21</groovy.version>
 
         <!-- Test -->
         <spock-core.version>1.3-groovy-2.4</spock-core.version>
-        <byte-buddy.version>1.10.13</byte-buddy.version>
+        <byte-buddy.version>1.10.22</byte-buddy.version>
         <logback-classic.version>1.2.3</logback-classic.version>
 
         <!-- Maven plugins -->
@@ -31,7 +31,8 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
-        <groovy-eclipse-compiler.version>3.6.0-03</groovy-eclipse-compiler.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <groovy-eclipse-compiler.version>3.7.0</groovy-eclipse-compiler.version>
         <groovy-eclipse-batch.version>2.4.21-01</groovy-eclipse-batch.version>
 
     </properties>
@@ -45,11 +46,10 @@
             <scope>provided</scope>
         </dependency>
 
-
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>${groovy-all.version}</version>
+            <version>${groovy.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -96,10 +96,22 @@
         </dependency>
 
     </dependencies>
+    
     <build>
         <defaultGoal>verify</defaultGoal>
         <sourceDirectory>src/main/groovy</sourceDirectory>
         <testSourceDirectory>src/test/groovy</testSourceDirectory>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/resources/projects/testDatasourceProject/reference/src/test/groovy/com/company/bonitasoft/IndexTest.groovy
+++ b/src/test/resources/projects/testDatasourceProject/reference/src/test/groovy/com/company/bonitasoft/IndexTest.groovy
@@ -13,7 +13,7 @@ import org.bonitasoft.web.extension.rest.RestAPIContext
 import java.time.LocalDate;
 
 /**
- * @see http://spockframework.github.io/spock/docs/1.0/index.html
+ * @see http://spockframework.github.io/spock/docs/
  */
 class IndexTest extends Specification {
 

--- a/src/test/resources/projects/testDatasourceProjectWithBDM/reference/pom.xml
+++ b/src/test/resources/projects/testDatasourceProjectWithBDM/reference/pom.xml
@@ -19,11 +19,11 @@
         <!-- Bonita -->
         <bonita.version>7.10.0</bonita.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
-        <groovy-all.version>2.4.21</groovy-all.version>
+        <groovy.version>2.4.21</groovy.version>
 
         <!-- Test -->
         <spock-core.version>1.3-groovy-2.4</spock-core.version>
-        <byte-buddy.version>1.10.13</byte-buddy.version>
+        <byte-buddy.version>1.10.22</byte-buddy.version>
         <logback-classic.version>1.2.3</logback-classic.version>
 
         <!-- Maven plugins -->
@@ -31,7 +31,8 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
-        <groovy-eclipse-compiler.version>3.6.0-03</groovy-eclipse-compiler.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <groovy-eclipse-compiler.version>3.7.0</groovy-eclipse-compiler.version>
         <groovy-eclipse-batch.version>2.4.21-01</groovy-eclipse-batch.version>
 
     </properties>
@@ -45,11 +46,10 @@
             <scope>provided</scope>
         </dependency>
 
-
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>${groovy-all.version}</version>
+            <version>${groovy.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -95,10 +95,22 @@
         </dependency>
 
     </dependencies>
+    
     <build>
         <defaultGoal>verify</defaultGoal>
         <sourceDirectory>src/main/groovy</sourceDirectory>
         <testSourceDirectory>src/test/groovy</testSourceDirectory>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/resources/projects/testDatasourceProjectWithBDM/reference/src/test/groovy/com/company/bonitasoft/IndexTest.groovy
+++ b/src/test/resources/projects/testDatasourceProjectWithBDM/reference/src/test/groovy/com/company/bonitasoft/IndexTest.groovy
@@ -13,7 +13,7 @@ import org.bonitasoft.web.extension.rest.RestAPIContext
 import java.time.LocalDate;
 
 /**
- * @see http://spockframework.github.io/spock/docs/1.0/index.html
+ * @see http://spockframework.github.io/spock/docs/
  */
 class IndexTest extends Specification {
 


### PR DESCRIPTION
In Bonita 7.13 Groovy has been updated to Groovy 3.0.7.
Using a `bonitaVersion` 7.13+ when creating a project will generate a
pom compliant with Groovy 3.

7.13- version still uses Groovy 2.4.x