### PR TITLE
tr(gh-action): replace deprecated github action create-release

### DIFF
--- a/.github/workflows/workflow-create-release.yml
+++ b/.github/workflows/workflow-create-release.yml
@@ -2,8 +2,8 @@ name: release build
 
 on:
   push:
-    branches: 
-      - release-* 
+    branches:
+      - release-*
 
 jobs:
   build:
@@ -20,33 +20,29 @@ jobs:
         with:
           java-version: 11
           distribution: 'temurin'
-      
+
       - name: Extract version
         shell: bash
         run: |
           extracted_version=$(echo ${GITHUB_REF#refs/heads/} | sed 's/release-//g')
           echo "version=$extracted_version" >> $GITHUB_OUTPUT
         id: extract_version
-      
+
       - name: changelog
-        uses: scottbrenner/generate-changelog-action@master 
+        uses: scottbrenner/generate-changelog-action@master
         id: Changelog
         env:
           REPO: ${{ github.repository }}
-      
+
       - name: Create Release
         id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ steps.extract_version.outputs.version }}
-          release_name: Release ${{ steps.extract_version.outputs.version }}
+          tag: ${{ steps.extract_version.outputs.version }}
+          name: Release ${{ steps.extract_version.outputs.version }}
           body: |
             ${{ steps.Changelog.outputs.changelog }}
-          draft: false
-          prerelease: false
-      
+
       - name: Release Maven archetype
         uses: samuelmeuli/action-maven-publish@v1
         with:


### PR DESCRIPTION
actions/create-release is not maintained anymore and is running on deprecated Node12 (see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

[JIRA CI-775](https://bonitasoft.atlassian.net/browse/CI-775)