### PR TITLE
chore: update bonitasoft.com domain references to ofelia.com

### DIFF
--- a/src/main/resources/archetype-resources/README.adoc
+++ b/src/main/resources/archetype-resources/README.adoc
@@ -27,7 +27,7 @@
 :imagesdir: ./doc/images
 
 :short-bonita-version: ${shortBonitaVersion}
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version:#if( $after10 ) 17#elseif ( $after713 ) 11#else 8#end
 
 

--- a/src/test/resources/projects/testDatasourceProject/reference/README.adoc
+++ b/src/test/resources/projects/testDatasourceProject/reference/README.adoc
@@ -12,7 +12,7 @@
 :imagesdir: ./doc/images
 
 :short-bonita-version: 7.10
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 8
 
 image::yourlogo.png[your logo here]

--- a/src/test/resources/projects/testDatasourceProject10/reference/README.adoc
+++ b/src/test/resources/projects/testDatasourceProject10/reference/README.adoc
@@ -12,7 +12,7 @@
 :imagesdir: ./doc/images
 
 :short-bonita-version: 10.0
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 17
 
 image::yourlogo.png[your logo here]

--- a/src/test/resources/projects/testDatasourceProject7_13/reference/README.adoc
+++ b/src/test/resources/projects/testDatasourceProject7_13/reference/README.adoc
@@ -12,7 +12,7 @@
 :imagesdir: ./doc/images
 
 :short-bonita-version: 7.13
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 11
 
 image::yourlogo.png[your logo here]

--- a/src/test/resources/projects/testJava11Project/reference/README.adoc
+++ b/src/test/resources/projects/testJava11Project/reference/README.adoc
@@ -12,7 +12,7 @@
 :imagesdir: ./doc/images
 
 :short-bonita-version: 7.15
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 11
 
 image::yourlogo.png[your logo here]

--- a/src/test/resources/projects/testJava11SpProject/reference/README.adoc
+++ b/src/test/resources/projects/testJava11SpProject/reference/README.adoc
@@ -12,7 +12,7 @@
 :imagesdir: ./doc/images
 
 :short-bonita-version: 7.13
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 11
 
 image::yourlogo.png[your logo here]

--- a/src/test/resources/projects/testJavaSpProject/reference/README.adoc
+++ b/src/test/resources/projects/testJavaSpProject/reference/README.adoc
@@ -12,7 +12,7 @@
 :imagesdir: ./doc/images
 
 :short-bonita-version: 10.0
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 17
 
 image::yourlogo.png[your logo here]

--- a/src/test/resources/projects/testKotlinProject/reference/README.adoc
+++ b/src/test/resources/projects/testKotlinProject/reference/README.adoc
@@ -12,7 +12,7 @@
 :imagesdir: ./doc/images
 
 :short-bonita-version: 7.10
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 8
 
 image::yourlogo.png[your logo here]

--- a/src/test/resources/projects/testKotlinProject7_13/reference/README.adoc
+++ b/src/test/resources/projects/testKotlinProject7_13/reference/README.adoc
@@ -12,7 +12,7 @@
 :imagesdir: ./doc/images
 
 :short-bonita-version: 7.13
-:doc-url: https://documentation.bonitasoft.com/bonita/{short-bonita-version}
+:doc-url: https://documentation.ofelia.com/bonita/{short-bonita-version}
 :java-version: 11
 
 image::yourlogo.png[your logo here]


### PR DESCRIPTION
## Summary
- Replace `documentation.bonitasoft.com` → `documentation.ofelia.com`
- Replace `community.bonitasoft.com` → `community.ofelia.com`
- Replace `www.bonitasoft.com` → `www.ofelia.com`

Affects README and archetype template files only. No logic changes.

Part of the Bonitasoft → Ofelia rebranding initiative.